### PR TITLE
Mark Dagostino: MrQ Lindar Challenge

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,14 +83,14 @@ You need to replicate the functionality and design as closely as possible to wha
   - Visually
   - The scroll behavior
 - The layout change between desktop and mobile devices.
-- Price chart should be visible only when a card is selected.
-- "+info" functionality (Show/hide the info on the cards)
-- Persistence of the active/selected card when navigating to other tabs.
+- Price chart should be visible only when a card is selected. ✅
+- "+info" functionality (Show/hide the info on the cards) ✅
+- Persistence of the active/selected card when navigating to other tabs. ✅
 - Responsiveness
 - Performance is critical!
-- Formatting of the currency
-- Improve initial loading time (do not try to measure, think of bundle size)
-- Fix race condition (Price History chart)
+- Formatting of the currency ✅
+- Improve initial loading time (do not try to measure, think of bundle size) ✅
+- Fix race condition (Price History chart) ✅
 - Follow established guidelines/practices in the project, such as:
   - Components structure
   - Imports/exports
@@ -151,7 +151,7 @@ The API call functionality is implemented. There is a flaw in the implementation
 **Try to fix this**.
 
 _(Hint: The flaw is in the `useEffect` hook. If for any reason the user has a slow connection,
-sometimes the price chart won't behave as expected)_
+sometimes the price chart won't behave as expected)_ ✅
 
 ### Stock Card
 

--- a/README.md
+++ b/README.md
@@ -74,26 +74,26 @@ You should push the starting project monorepo to a private (personal) repository
 You need to replicate the functionality and design as closely as possible to what is shown in the videos and images.
 
 - Fully replicate the card , including:
-  - Shake Animation (It is provided in the CSS)
-  - The Glow states
-  - The scaling and glow on user interaction (select/unselected)
-  - The trend indicator (red/green arrows)
+  - Shake Animation (It is provided in the CSS) ✅
+  - The Glow states ✅
+  - The scaling and glow on user interaction (select/unselected) ✅
+  - The trend indicator (red/green arrows) ✅
   - The implementation of the `SymbolCard` should be as granular as possible, i.e. SymbolCard should be a "smart" component built with "dumb" components. ✅
-- The Cards container
-  - Visually
-  - The scroll behavior
-- The layout change between desktop and mobile devices.
+- The Cards container ✅
+  - Visually ✅
+  - The scroll behavior ✅
+- The layout change between desktop and mobile devices.✅
 - Price chart should be visible only when a card is selected. ✅
 - "+info" functionality (Show/hide the info on the cards) ✅
 - Persistence of the active/selected card when navigating to other tabs. ✅
-- Responsiveness
-- Performance is critical!
+- Responsiveness ✅
+- Performance is critical! ✅
 - Formatting of the currency ✅
 - Improve initial loading time (do not try to measure, think of bundle size) ✅
 - Fix race condition (Price History chart) ✅
 - Follow established guidelines/practices in the project, such as:
-  - Components structure
-  - Imports/exports
+  - Components structure ✅
+  - Imports/exports ✅
 
 #### Hints / Recommendations:
 
@@ -102,14 +102,14 @@ You need to replicate the functionality and design as closely as possible to wha
 
 ## Guidelines
 
-- **The final solution should be highly optimized and implemented as efficiently as possible. In other words, the number of re-renders of the components and the bundle size on initial load should be as low
+- **The final solution should be highly optimized and implemented as efficiently as possible. In other words, the number of re-renders of the components and the bundle size on initial load should be as low ✅
   as possible.** For example:
-  - When the effects are active (shaking, glowing, etc.) the children of the component should not be re-rendered.
-  - You should avoid re-rendering the whole component when only a part of it needs to be updated.
+  - When the effects are active (shaking, glowing, etc.) the children of the component should not be re-rendered. ✅
+  - You should avoid re-rendering the whole component when only a part of it needs to be updated. ✅
   - _(Hint: For the initial bundle size, in [router/index.ts](frontend/src/router/index.tsx), something combined with `Suspense` will get you there.)_ ✅
 - **Please ensure that the code you submit reflects your best work and you use best practices.**
 - **The commit history should be granular with descriptive commit comments**
-- **You should write custom CSS (in other words, do not use UI Libraries). Using [BEM methodology](https://getbem.com/naming/) for CSS classes is a nice to have but not required.**
+- **You should write custom CSS (in other words, do not use UI Libraries). Using [BEM methodology](https://getbem.com/naming/) for CSS classes is a nice to have but not required.** ✅
   - You can use postcss, sass, less, etc. if you prefer.
 - **Avoid writing inline styles.**
 
@@ -124,23 +124,23 @@ The layout consists of a `heading`,`info cards`, `news cards`, `navigation`, `st
 The layout should be responsive and should be able to be displayed on desktop, tablet and mobile devices.
 
 - On desktop devices the price chart should take `400px` of the width. The remaining
-  width should be used for the stock cards list.
+  width should be used for the stock cards list. ✅
 - On tablet/mobile and other devices with screen smaller than `1024px`, the price chart should be displayed above the
-  stock cards list.
+  stock cards list. ✅
 
 ### Stock Card List
 
 The cards should be displayed in a responsive container. The container
-should take the remaining of the height from the page
+should take the remaining of the height from the page ✅
 
-- bellow the title and navigation on desktop
-- bellow the title, navigation and chart on tablet/mobile
+- bellow the title and navigation on desktop ✅
+- bellow the title, navigation and chart on tablet/mobile ✅
 
 #### User Actions:
 
 - The user should be able to select a stock card by clicking on it. When a card is selected, it should be highlighted
-  with black shadow and scaled up by around 2-4%. (Check video/images)
-- If there is an active/selected card, the other cards should be scaled down by around 2-4%. (Check video/images)
+  with black shadow and scaled up by around 2-4%. (Check video/images) ✅
+- If there is an active/selected card, the other cards should be scaled down by around 2-4%. (Check video/images) ✅
 
 [dashboard card active](instruction_assets/dashboard_card_active.png)
 
@@ -165,34 +165,34 @@ sometimes the price chart won't behave as expected)_ ✅
 
 #### Variations
 
-- Default _(no trend)_
-- Positive trend _(green upwards arrow)_
-- Negative trend _(red downwards arrows)_
+- Default _(no trend)_ ✅
+- Positive trend _(green upwards arrow)_ ✅
+- Negative trend _(red downwards arrows)_ ✅
 
 #### Fields
 
 - **Header**: Header title is the stock symbol. On the right side of the header there is a
-  trend marker (only if the trend is available)
+  trend marker (only if the trend is available) ✅
 
-- **Trend Marker**: Some stocks may have a positive or negative
+- **Trend Marker**: Some stocks may have a positive or negative ✅
   trend which is indicated by **green** _(positive)_ and **red** _(negative)_ arrows.
   Assets for this can be found in the [frontend/src/assets](frontend/src/assets) folder.
 - `assets` folder.
 
-- **Price** _(in USD)_: Formatted price of the stock.
-- **Company Name, Industry and Market cap**: Info fields about the stock.
+- **Price** _(in USD)_: Formatted price of the stock. ✅
+- **Company Name, Industry and Market cap**: Info fields about the stock. ✅
   Assets for this can be found in the [frontend/src/assets](frontend/src/assets) folder.
 
 #### Animations/Interactions specs
 
 - If the price changes for more than 25% from the previous price, the card should shake
-  - The shake animation class can be found in the [frontend/src/components/SymbolCard/symbolCard.css](frontend/src/components/SymbolCard/symbolCard.css) `symbolCard__shake`.
-- If the `last price` change is `positive`, the card should flash with `green shadow`. (Check videos)
-- If the `last price` change is `negative`, the card should flash with `red shadow`. (Check videos)
-- If the card is currently selected, it should have a black shadow around it. (Check videos)
+  - The shake animation class can be found in the [frontend/src/components/SymbolCard/symbolCard.css](frontend/src/components/SymbolCard/symbolCard.css) `symbolCard__shake`. ✅
+- If the `last price` change is `positive`, the card should flash with `green shadow`. (Check videos) ✅
+- If the `last price` change is `negative`, the card should flash with `red shadow`. (Check videos) ✅
+- If the card is currently selected, it should have a black shadow around it. (Check videos) ✅
   - **NOTE**: The flashing shadow from the price changes takes precedence over the black shadow that is shown when a card is selected. (Check videos)
 
-### Bonus points for using custom hooks, especially for the **animations** and **effects (box shadow)**
+### Bonus points for using custom hooks, especially for the **animations** and **effects (box shadow)** ✅
 
 ### ESTIMATED TIME: 2-4 hours
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ You need to replicate the functionality and design as closely as possible to wha
   - The Glow states
   - The scaling and glow on user interaction (select/unselected)
   - The trend indicator (red/green arrows)
-  - The implementation of the `SymbolCard` should be as granular as possible, i.e. SymbolCard should be a "smart" component built with "dumb" components.
+  - The implementation of the `SymbolCard` should be as granular as possible, i.e. SymbolCard should be a "smart" component built with "dumb" components. ✅
 - The Cards container
   - Visually
   - The scroll behavior
@@ -106,7 +106,7 @@ You need to replicate the functionality and design as closely as possible to wha
   as possible.** For example:
   - When the effects are active (shaking, glowing, etc.) the children of the component should not be re-rendered.
   - You should avoid re-rendering the whole component when only a part of it needs to be updated.
-  - _(Hint: For the initial bundle size, in [router/index.ts](frontend/src/router/index.tsx), something combined with `Suspense` will get you there.)_
+  - _(Hint: For the initial bundle size, in [router/index.ts](frontend/src/router/index.tsx), something combined with `Suspense` will get you there.)_ ✅
 - **Please ensure that the code you submit reflects your best work and you use best practices.**
 - **The commit history should be granular with descriptive commit comments**
 - **You should write custom CSS (in other words, do not use UI Libraries). Using [BEM methodology](https://getbem.com/naming/) for CSS classes is a nice to have but not required.**

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>STOCKS - Home Assignment</title>
+    <title>STONKS - Home Assignment</title>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/notes.md
+++ b/frontend/notes.md
@@ -1,0 +1,90 @@
+# 1. Fixing the Price History Chart Race Condition
+
+**The Issue:**
+
+- When switching stocks quickly, multiple fetches for price history could overlap.
+- A slower (previous) fetch could finish after a faster (newer) one, causing the chart to show outdated data.
+
+**Why It Happens:**
+
+- Each fetch is asynchronous and independent.
+- Redux state is updated by whichever fetch finishes last, regardless of which stock is currently selected.
+
+**The Solution:**
+
+- Use Redux Toolkit’s built-in `thunkAPI.signal` in the async thunk to automatically abort previous fetches when a new one starts.
+- This ensures only the latest fetch updates the state, so the chart always matches the selected stock.
+- In addition, the chart data is cleared immediately when a new stock is selected, so no stale data is shown while loading.
+
+**Result:**
+
+- Now, when you switch stocks quickly, only the latest selected stock’s price history is shown.
+- No more mismatched or outdated charts, even on a slow connection.
+
+---
+
+# 2. Persisting the Active Card Selection with Redux
+
+**Why?**
+
+- Needed to keep the selected (active) card highlighted even when navigating between pages.
+- Local state (`useState`) would reset on navigation; global state (Redux) persists.
+
+**What Was Added?**
+
+- Added `activeSymbol` to the Redux slice (`dashboardOptionsSlice`).
+- Created an action `setActiveSymbol` to update the active card.
+- Created a selector `selectActiveSymbol` to access the current active card from anywhere.
+
+**How Is It Used?**
+
+- In `SymbolsView.tsx`, replaced `useState` with `useAppSelector(selectActiveSymbol)` and `dispatch(setActiveSymbol(...))`.
+- When a card is clicked, `setActiveSymbol` is dispatched with the card’s symbol.
+- The `activeSymbol` value is passed to each `SymbolCard` (via `SymbolsGrid`) as the `isActive` prop.
+
+**How Does It Affect the UI?**
+
+- The `isActive` prop adds a CSS class to the active card for styling.
+- The selected card remains highlighted and the chart remains visible, even after navigating away and back.
+
+**Why Is This Best Practice?**
+
+- Keeps UI state that should persist across routes in a single, global place (Redux).
+- Avoids prop drilling and unnecessary re-renders.
+- Makes the app more predictable and easier to maintain.
+
+---
+
+# 3. Reducing Initial Bundle Size with React Suspense and Lazy Loading
+
+**Why?**
+
+- To improve the initial load time of the app by only loading the code needed for the first screen.
+- Large apps can have many components and views, but users usually only need the main dashboard at first.
+
+**What Was Added?**
+
+- Used `React.lazy` and `Suspense` in the router to load each main view (Dashboard, Profile, Statements) only when the user navigates to them.
+- This means the code for Profile and Statements is not loaded until the user actually visits those pages.
+
+**How Is It Used?**
+
+- In `src/router/index.tsx`, each route uses a lazy import:
+  ```tsx
+  const SymbolsView = lazy(() => import('@/components/SymbolsView'));
+  // ...
+  <Suspense fallback={<div>Loading...</div>}>
+    <Routes>
+      <Route index element={<SymbolsView />} />
+      ...
+    </Routes>
+  </Suspense>;
+  ```
+- The `Suspense` component shows a loading indicator while the new view is being loaded.
+
+**Result:**
+
+- The initial JavaScript bundle is smaller, so the app loads faster for the user.
+- Additional code is only loaded as needed, improving performance and user experience.
+
+---

--- a/frontend/notes.md
+++ b/frontend/notes.md
@@ -88,3 +88,61 @@
 - Additional code is only loaded as needed, improving performance and user experience.
 
 ---
+
+# 4. Custom Animation Hooks: useFlashEffect & useShakeEffect
+
+**Why custom hooks?**
+
+- To encapsulate animation logic (flash and shake) for stock cards, keeping SymbolCard clean and minimizing re-renders.
+- Each hook tracks price changes using refs and state, and only updates the card's className (not its children or content).
+
+**useFlashEffect**
+
+- Triggers a green or red box-shadow flash when the price increases or decreases.
+- Returns a className string (e.g., 'symbolCard**flash--green' or 'symbolCard**flash--red') for use in the card's class list.
+- Uses refs to track the previous price and a timer to remove the class after the animation duration.
+- Ensures the flash effect takes precedence over the active (black shadow) state.
+
+**useShakeEffect**
+
+- Triggers a shake animation if the price changes by more than 25% (up or down).
+- Returns a className string ('symbolCard\_\_shake') for use in the card's class list.
+- Uses refs to track the previous price and a timer to remove the class after the animation duration.
+
+**Why keep them separate?**
+
+- Each effect is independent and may have different triggers and durations.
+- Separation keeps logic simple, reusable, and easy to test or extend.
+- Both hooks are highly efficient: they use refs and state to avoid unnecessary re-renders, and SymbolCard's children are memoized.
+
+**Usage in SymbolCard:**
+
+- Both hooks are called with the current price.
+- The returned classNames are combined in the card's className prop.
+- This approach ensures maximum performance and a clean, maintainable codebase.
+
+---
+
+# 5. Granular SymbolCard Component Structure
+
+**Why granular?**
+
+- Splitting SymbolCard into small, focused subcomponents improves maintainability, testability, and performance.
+- Each subcomponent is responsible for a single part of the card, making the codebase easier to reason about and update.
+
+**How SymbolCard is split:**
+
+- `SymbolCardHeader`: Renders the stock symbol and the trend marker (arrow), using a dedicated `SymbolCardTrendIcon` for the arrow.
+- `SymbolCardPrice`: Displays the formatted price.
+- `SymbolCardInfo`: Shows company name, industry, and market cap, each as a ListItem with an icon.
+- The main `SymbolCard` component only handles layout, click logic, and animation classNames. It does not contain any UI logic for the card's fields.
+
+**Benefits:**
+
+- Each part of the card can be memoized independently, so price flashes or shakes do not cause unnecessary re-renders of the info or header.
+- Easier to test and update individual parts (e.g., changing how the trend icon works does not affect the rest of the card).
+- Keeps SymbolCard clean and focused on composition and interaction, not rendering details.
+
+**Summary:**
+
+- This granular approach is a best practice for React, especially in performance-sensitive UIs like dashboards.

--- a/frontend/src/components/ListItem/listItem.css
+++ b/frontend/src/components/ListItem/listItem.css
@@ -1,5 +1,6 @@
 .listItem {
   display: flex;
+  justify-content: space-between;
   flex-direction: row;
   align-items: center;
   padding: 4px;

--- a/frontend/src/components/PerformanceCard/performanceCard.css
+++ b/frontend/src/components/PerformanceCard/performanceCard.css
@@ -12,5 +12,6 @@
   box-shadow: 2px 2px 4px rgba(0, 0, 0, 0.1);
 }
 
-.performanceCard {
+.performanceCard .listItem {
+  justify-content: flex-start;
 }

--- a/frontend/src/components/PerformanceCard/src/VolumeLabel.tsx
+++ b/frontend/src/components/PerformanceCard/src/VolumeLabel.tsx
@@ -3,6 +3,7 @@ import './performanceInfo.css';
 import { ReactComponent as UpArrow } from '@/assets/up-arrow.svg';
 import { ReactComponent as DownArrow } from '@/assets/down-arrow.svg';
 import ListItem from '@/components/ListItem';
+import { formatNumber } from '@/utils/formatNumber';
 
 type TrendLabelProps = {
   volume: number;
@@ -11,6 +12,6 @@ type TrendLabelProps = {
 
 const VolumeLabel = ({ volume, change }: TrendLabelProps) => {
   const arrow = change > 1 ? <UpArrow /> : <DownArrow />;
-  return <ListItem Icon={arrow} label={volume.toString()} />;
+  return <ListItem Icon={arrow} label={formatNumber(volume)} />;
 };
 export default memo(VolumeLabel);

--- a/frontend/src/components/PriceChart/PriceChart.tsx
+++ b/frontend/src/components/PriceChart/PriceChart.tsx
@@ -1,8 +1,8 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import './priceChart.css';
 import { Line, LineChart, XAxis, YAxis, ResponsiveContainer } from 'recharts';
 import { useAppDispatch, useAppSelector } from '@/hooks/redux';
-import { fetchPriceHistory, selectors, reset } from '@/store/priceHistorySlice';
+import { fetchPriceHistory, selectors } from '@/store/priceHistorySlice';
 import Loading from '@/components/Loading';
 type PriceChartProps = {
   symbolId: string | null;
@@ -10,14 +10,14 @@ type PriceChartProps = {
 
 const PriceChart = ({ symbolId }: PriceChartProps) => {
   const dispatch = useAppDispatch();
+  const prevSymbolRef = useRef<string | null>(null);
+
   useEffect(() => {
-    if (symbolId) {
-      dispatch(reset()); 
+    if (symbolId && symbolId !== prevSymbolRef.current) {
+      prevSymbolRef.current = symbolId;
       dispatch(fetchPriceHistory(symbolId));
-    } else {
-      dispatch(reset());
     }
-  }, [dispatch, symbolId]);
+  }, [symbolId, dispatch]);
 
   const apiState = useAppSelector(selectors.apiState);
   const data = useAppSelector(selectors.selectPriceHistory);

--- a/frontend/src/components/PriceChart/PriceChart.tsx
+++ b/frontend/src/components/PriceChart/PriceChart.tsx
@@ -2,7 +2,7 @@ import { useEffect } from 'react';
 import './priceChart.css';
 import { Line, LineChart, XAxis, YAxis, ResponsiveContainer } from 'recharts';
 import { useAppDispatch, useAppSelector } from '@/hooks/redux';
-import { fetchPriceHistory, selectors } from '@/store/priceHistorySlice';
+import { fetchPriceHistory, selectors, reset } from '@/store/priceHistorySlice';
 import Loading from '@/components/Loading';
 type PriceChartProps = {
   symbolId: string | null;
@@ -12,7 +12,10 @@ const PriceChart = ({ symbolId }: PriceChartProps) => {
   const dispatch = useAppDispatch();
   useEffect(() => {
     if (symbolId) {
+      dispatch(reset()); 
       dispatch(fetchPriceHistory(symbolId));
+    } else {
+      dispatch(reset());
     }
   }, [dispatch, symbolId]);
 

--- a/frontend/src/components/PriceChart/priceChart.css
+++ b/frontend/src/components/PriceChart/priceChart.css
@@ -4,7 +4,7 @@
   display: flex;
 }
 
-@media (max-width: 1023px) {
+@media (max-width: 1024px) {
   .priceChart {
     max-height: 250px;
     height: 180px;

--- a/frontend/src/components/SymbolCard/SymbolCard.tsx
+++ b/frontend/src/components/SymbolCard/SymbolCard.tsx
@@ -10,16 +10,17 @@ type SymbolCardProps = {
   id: string;
   onClick: (symbolId: string) => void;
   price: number;
+  isActive: boolean;
 };
 
-const SymbolCard = ({ id, onClick, price }: SymbolCardProps) => {
+const SymbolCard = ({ id, onClick, price, isActive }: SymbolCardProps) => {
   const { trend, companyName, industry, marketCap } = useAppSelector((state) => state.stocks.entities[id]);
   const showCardInfo = useAppSelector(selectShowCardInfo);
   const handleOnClick = () => {
     onClick(id);
   };
   return (
-    <div onClick={handleOnClick} className="symbolCard">
+    <div onClick={handleOnClick} className={`symbolCard${isActive ? ' symbolCard--active' : ''}`}>
       <div>
         {id} - {trend}
       </div>

--- a/frontend/src/components/SymbolCard/SymbolCard.tsx
+++ b/frontend/src/components/SymbolCard/SymbolCard.tsx
@@ -1,6 +1,7 @@
+import { memo, useCallback, useMemo } from 'react';
 import './symbolCard.css';
-import { useAppSelector } from '@/hooks/redux';
-import { selectShowCardInfo } from '@/store/dashboardOptionsSlice';
+import { useAppSelector, useAppDispatch } from '@/hooks/redux';
+import { selectShowCardInfo, selectActiveSymbol, setActiveSymbol } from '@/store/dashboardOptionsSlice';
 import SymbolCardHeader from './SymbolCardHeader';
 import SymbolCardPrice from './SymbolCardPrice';
 import SymbolCardInfo from './SymbolCardInfo';
@@ -9,25 +10,28 @@ import { useShakeEffect } from '@/hooks/useShakeEffect';
 
 type SymbolCardProps = {
   id: string;
-  onClick: (symbolId: string) => void;
-  price: number;
-  isActive: boolean;
-  isInactive: boolean;
 };
 
-const SymbolCard = ({ id, onClick, price, isActive, isInactive }: SymbolCardProps) => {
+const SymbolCard = memo(({ id }: SymbolCardProps) => {
+  const dispatch = useAppDispatch();
   const { trend, companyName, industry, marketCap } = useAppSelector(
     (state) => state.stocks.entities[id]
   );
+  const price = useAppSelector((state) => state.prices[id]);
+  const activeSymbol = useAppSelector(selectActiveSymbol);
   const showCardInfo = useAppSelector(selectShowCardInfo);
-  const handleOnClick = () => {
-    onClick(id);
-  };
+  
+  const handleOnClick = useCallback(() => {
+    dispatch(setActiveSymbol(id === activeSymbol ? null : id));
+  }, [dispatch, id, activeSymbol]);
 
   const { flashClass } = useFlashEffect(price);
   const { shakeClass } = useShakeEffect(price);
 
-  const cardClass = [
+  const isActive = id === activeSymbol;
+  const isInactive = !!activeSymbol && id !== activeSymbol;
+
+  const cardClass = useMemo(() => [
     'symbolCard',
     flashClass,
     shakeClass,
@@ -35,7 +39,7 @@ const SymbolCard = ({ id, onClick, price, isActive, isInactive }: SymbolCardProp
     isInactive ? 'symbolCard--inactive' : ''
   ]
     .filter(Boolean)
-    .join(' ');
+    .join(' '), [flashClass, shakeClass, isActive, isInactive]);
 
   return (
     <div onClick={handleOnClick} className={cardClass}>
@@ -46,5 +50,5 @@ const SymbolCard = ({ id, onClick, price, isActive, isInactive }: SymbolCardProp
       )}
     </div>
   );
-};
+});
 export default SymbolCard;

--- a/frontend/src/components/SymbolCard/SymbolCard.tsx
+++ b/frontend/src/components/SymbolCard/SymbolCard.tsx
@@ -1,11 +1,9 @@
 import './symbolCard.css';
-import { ReactComponent as CompanyIcon } from '@/assets/company.svg';
-import { ReactComponent as IndustryIcon } from '@/assets/industry.svg';
-import { ReactComponent as MarketCapIcon } from '@/assets/market_cap.svg';
 import { useAppSelector } from '@/hooks/redux';
-import ListItem from '@/components/ListItem';
 import { selectShowCardInfo } from '@/store/dashboardOptionsSlice';
-import { formatNumber } from '@/utils/formatNumber';
+import SymbolCardHeader from './SymbolCardHeader';
+import SymbolCardPrice from './SymbolCardPrice';
+import SymbolCardInfo from './SymbolCardInfo';
 
 type SymbolCardProps = {
   id: string;
@@ -20,19 +18,13 @@ const SymbolCard = ({ id, onClick, price, isActive }: SymbolCardProps) => {
   const handleOnClick = () => {
     onClick(id);
   };
+
   return (
     <div onClick={handleOnClick} className={`symbolCard${isActive ? ' symbolCard--active' : ''}`}>
-      <div>
-        {id} - {trend}
-      </div>
-      <div>Price:</div>
-      <div>{formatNumber(price)} </div>
+      <SymbolCardHeader symbol={id} trend={trend} />
+      <SymbolCardPrice price={price} />
       {showCardInfo && (
-        <>
-          <ListItem Icon={<CompanyIcon />} label={companyName} />
-          <ListItem Icon={<IndustryIcon />} label={industry} />
-          <ListItem Icon={<MarketCapIcon />} label={formatNumber(marketCap)} />
-        </>
+        <SymbolCardInfo companyName={companyName} industry={industry} marketCap={marketCap} />
       )}
     </div>
   );

--- a/frontend/src/components/SymbolCard/SymbolCard.tsx
+++ b/frontend/src/components/SymbolCard/SymbolCard.tsx
@@ -5,6 +5,7 @@ import { ReactComponent as MarketCapIcon } from '@/assets/market_cap.svg';
 import { useAppSelector } from '@/hooks/redux';
 import ListItem from '@/components/ListItem';
 import { selectShowCardInfo } from '@/store/dashboardOptionsSlice';
+import { formatNumber } from '@/utils/formatNumber';
 
 type SymbolCardProps = {
   id: string;
@@ -25,12 +26,12 @@ const SymbolCard = ({ id, onClick, price, isActive }: SymbolCardProps) => {
         {id} - {trend}
       </div>
       <div>Price:</div>
-      <div>{price || '--'} </div>
+      <div>{formatNumber(price)} </div>
       {showCardInfo && (
         <>
           <ListItem Icon={<CompanyIcon />} label={companyName} />
           <ListItem Icon={<IndustryIcon />} label={industry} />
-          <ListItem Icon={<MarketCapIcon />} label={marketCap.toString()} />
+          <ListItem Icon={<MarketCapIcon />} label={formatNumber(marketCap)} />
         </>
       )}
     </div>

--- a/frontend/src/components/SymbolCard/SymbolCard.tsx
+++ b/frontend/src/components/SymbolCard/SymbolCard.tsx
@@ -4,6 +4,7 @@ import { selectShowCardInfo } from '@/store/dashboardOptionsSlice';
 import SymbolCardHeader from './SymbolCardHeader';
 import SymbolCardPrice from './SymbolCardPrice';
 import SymbolCardInfo from './SymbolCardInfo';
+import { useFlashEffect } from '@/hooks/useFlashEffect';
 
 type SymbolCardProps = {
   id: string;
@@ -20,8 +21,11 @@ const SymbolCard = ({ id, onClick, price, isActive, isInactive }: SymbolCardProp
     onClick(id);
   };
 
+  const flashClass = useFlashEffect(price);
+
   const cardClass = [
     'symbolCard',
+    flashClass,
     isActive ? 'symbolCard--active' : '',
     isInactive ? 'symbolCard--inactive' : ''
   ].filter(Boolean).join(' ');

--- a/frontend/src/components/SymbolCard/SymbolCard.tsx
+++ b/frontend/src/components/SymbolCard/SymbolCard.tsx
@@ -1,7 +1,10 @@
 import './symbolCard.css';
 import { ReactComponent as CompanyIcon } from '@/assets/company.svg';
+import { ReactComponent as IndustryIcon } from '@/assets/industry.svg';
+import { ReactComponent as MarketCapIcon } from '@/assets/market_cap.svg';
 import { useAppSelector } from '@/hooks/redux';
 import ListItem from '@/components/ListItem';
+import { selectShowCardInfo } from '@/store/dashboardOptionsSlice';
 
 type SymbolCardProps = {
   id: string;
@@ -10,7 +13,8 @@ type SymbolCardProps = {
 };
 
 const SymbolCard = ({ id, onClick, price }: SymbolCardProps) => {
-  const { trend, companyName } = useAppSelector((state) => state.stocks.entities[id]);
+  const { trend, companyName, industry, marketCap } = useAppSelector((state) => state.stocks.entities[id]);
+  const showCardInfo = useAppSelector(selectShowCardInfo);
   const handleOnClick = () => {
     onClick(id);
   };
@@ -21,7 +25,13 @@ const SymbolCard = ({ id, onClick, price }: SymbolCardProps) => {
       </div>
       <div>Price:</div>
       <div>{price || '--'} </div>
-      <ListItem Icon={<CompanyIcon />} label={companyName} />
+      {showCardInfo && (
+        <>
+          <ListItem Icon={<CompanyIcon />} label={companyName} />
+          <ListItem Icon={<IndustryIcon />} label={industry} />
+          <ListItem Icon={<MarketCapIcon />} label={marketCap.toString()} />
+        </>
+      )}
     </div>
   );
 };

--- a/frontend/src/components/SymbolCard/SymbolCard.tsx
+++ b/frontend/src/components/SymbolCard/SymbolCard.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useMemo } from 'react';
+import { memo, useMemo } from 'react';
 import './symbolCard.css';
 import { useAppSelector, useAppDispatch } from '@/hooks/redux';
 import { selectShowCardInfo, selectActiveSymbol, setActiveSymbol } from '@/store/dashboardOptionsSlice';
@@ -20,10 +20,10 @@ const SymbolCard = memo(({ id }: SymbolCardProps) => {
   const price = useAppSelector((state) => state.prices[id]);
   const activeSymbol = useAppSelector(selectActiveSymbol);
   const showCardInfo = useAppSelector(selectShowCardInfo);
-  
-  const handleOnClick = useCallback(() => {
+
+  const handleOnClick = () => {
     dispatch(setActiveSymbol(id === activeSymbol ? null : id));
-  }, [dispatch, id, activeSymbol]);
+  };
 
   const { flashClass } = useFlashEffect(price);
   const { shakeClass } = useShakeEffect(price);

--- a/frontend/src/components/SymbolCard/SymbolCard.tsx
+++ b/frontend/src/components/SymbolCard/SymbolCard.tsx
@@ -10,17 +10,24 @@ type SymbolCardProps = {
   onClick: (symbolId: string) => void;
   price: number;
   isActive: boolean;
+  isInactive: boolean;
 };
 
-const SymbolCard = ({ id, onClick, price, isActive }: SymbolCardProps) => {
+const SymbolCard = ({ id, onClick, price, isActive, isInactive }: SymbolCardProps) => {
   const { trend, companyName, industry, marketCap } = useAppSelector((state) => state.stocks.entities[id]);
   const showCardInfo = useAppSelector(selectShowCardInfo);
   const handleOnClick = () => {
     onClick(id);
   };
 
+  const cardClass = [
+    'symbolCard',
+    isActive ? 'symbolCard--active' : '',
+    isInactive ? 'symbolCard--inactive' : ''
+  ].filter(Boolean).join(' ');
+
   return (
-    <div onClick={handleOnClick} className={`symbolCard${isActive ? ' symbolCard--active' : ''}`}>
+    <div onClick={handleOnClick} className={cardClass}>
       <SymbolCardHeader symbol={id} trend={trend} />
       <SymbolCardPrice price={price} />
       {showCardInfo && (

--- a/frontend/src/components/SymbolCard/SymbolCard.tsx
+++ b/frontend/src/components/SymbolCard/SymbolCard.tsx
@@ -5,6 +5,7 @@ import SymbolCardHeader from './SymbolCardHeader';
 import SymbolCardPrice from './SymbolCardPrice';
 import SymbolCardInfo from './SymbolCardInfo';
 import { useFlashEffect } from '@/hooks/useFlashEffect';
+import { useShakeEffect } from '@/hooks/useShakeEffect';
 
 type SymbolCardProps = {
   id: string;
@@ -22,10 +23,12 @@ const SymbolCard = ({ id, onClick, price, isActive, isInactive }: SymbolCardProp
   };
 
   const flashClass = useFlashEffect(price);
+  const { shakeClass } = useShakeEffect(price);
 
   const cardClass = [
     'symbolCard',
     flashClass,
+    shakeClass,
     isActive ? 'symbolCard--active' : '',
     isInactive ? 'symbolCard--inactive' : ''
   ].filter(Boolean).join(' ');

--- a/frontend/src/components/SymbolCard/SymbolCard.tsx
+++ b/frontend/src/components/SymbolCard/SymbolCard.tsx
@@ -16,13 +16,15 @@ type SymbolCardProps = {
 };
 
 const SymbolCard = ({ id, onClick, price, isActive, isInactive }: SymbolCardProps) => {
-  const { trend, companyName, industry, marketCap } = useAppSelector((state) => state.stocks.entities[id]);
+  const { trend, companyName, industry, marketCap } = useAppSelector(
+    (state) => state.stocks.entities[id]
+  );
   const showCardInfo = useAppSelector(selectShowCardInfo);
   const handleOnClick = () => {
     onClick(id);
   };
 
-  const flashClass = useFlashEffect(price);
+  const { flashClass } = useFlashEffect(price);
   const { shakeClass } = useShakeEffect(price);
 
   const cardClass = [
@@ -31,7 +33,9 @@ const SymbolCard = ({ id, onClick, price, isActive, isInactive }: SymbolCardProp
     shakeClass,
     isActive ? 'symbolCard--active' : '',
     isInactive ? 'symbolCard--inactive' : ''
-  ].filter(Boolean).join(' ');
+  ]
+    .filter(Boolean)
+    .join(' ');
 
   return (
     <div onClick={handleOnClick} className={cardClass}>

--- a/frontend/src/components/SymbolCard/SymbolCardHeader.tsx
+++ b/frontend/src/components/SymbolCard/SymbolCardHeader.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import SymbolCardTrendIcon from '@/components/SymbolCard/SymbolCardTrendIcon';
+
+type SymbolCardHeaderProps = {
+  symbol: string;
+  trend: 'UP' | 'DOWN' | null;
+};
+
+const SymbolCardHeader = ({ symbol, trend }: SymbolCardHeaderProps) => (
+  <div className="symbolCard__header">
+    <span>{symbol}</span>
+    <SymbolCardTrendIcon trend={trend} />
+  </div>
+);
+
+export default React.memo(SymbolCardHeader);

--- a/frontend/src/components/SymbolCard/SymbolCardInfo.tsx
+++ b/frontend/src/components/SymbolCard/SymbolCardInfo.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import ListItem from '@/components/ListItem';
+import { ReactComponent as CompanyIcon } from '@/assets/company.svg';
+import { ReactComponent as IndustryIcon } from '@/assets/industry.svg';
+import { ReactComponent as MarketCapIcon } from '@/assets/market_cap.svg';
+import { formatNumber } from '@/utils/formatNumber';
+
+type SymbolCardInfoProps = {
+  companyName: string;
+  industry: string;
+  marketCap: number;
+};
+
+const SymbolCardInfo = ({ companyName, industry, marketCap }: SymbolCardInfoProps) => (
+  <div className="symbolCard__info">
+    <ListItem Icon={<CompanyIcon />} label={companyName} />
+    <ListItem Icon={<IndustryIcon />} label={industry} />
+    <ListItem Icon={<MarketCapIcon />} label={formatNumber(marketCap)} />
+  </div>
+);
+
+export default React.memo(SymbolCardInfo);

--- a/frontend/src/components/SymbolCard/SymbolCardPrice.tsx
+++ b/frontend/src/components/SymbolCard/SymbolCardPrice.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { formatNumber } from '@/utils/formatNumber';
+
+type SymbolCardPriceProps = {
+  price: number;
+};
+
+const SymbolCardPrice = ({ price }: SymbolCardPriceProps) => (
+  <div className="symbolCard__priceRow">
+    <span className="symbolCard__priceLabel">PRICE:</span>
+    <span className="symbolCard__priceValue">{formatNumber(price)}</span>
+  </div>
+);
+
+export default React.memo(SymbolCardPrice);

--- a/frontend/src/components/SymbolCard/SymbolCardTrendIcon.tsx
+++ b/frontend/src/components/SymbolCard/SymbolCardTrendIcon.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import upArrow from '@/assets/up.png';
+import downArrow from '@/assets/down.png';
+
+type SymbolCardTrendIconProps = {
+  trend: 'UP' | 'DOWN' | null;
+};
+
+const SymbolCardTrendIcon = ({ trend }: SymbolCardTrendIconProps) => {
+  if (trend === 'UP') {
+    return (
+      <span className="symbolCard__trendWrapper">
+        <img src={upArrow} alt="up" className="symbolCard__trend" />
+      </span>
+    );
+  }
+  if (trend === 'DOWN') {
+    return (
+      <span className="symbolCard__trendWrapper">
+        <img src={downArrow} alt="down" className="symbolCard__trend" />
+      </span>
+    );
+  }
+  return null;
+};
+
+export default React.memo(SymbolCardTrendIcon);

--- a/frontend/src/components/SymbolCard/symbolCard.css
+++ b/frontend/src/components/SymbolCard/symbolCard.css
@@ -15,7 +15,7 @@
 }
 
 .symbolCard--active {
-  box-shadow: 0 4px 32px 0 rgba(0, 0, 0, 0.8), 0 2px 16px 0 rgba(14, 17, 35, 0.1);
+  box-shadow: 0 4px 32px 0 rgba(0, 0, 0, 1), 0 2px 16px 0 rgba(14, 17, 35, 0.1);
   transform: scale(1.02);
   z-index: 1;
 }
@@ -46,18 +46,20 @@
 }
 
 .symbolCard__trendWrapper {
-  margin-left: 8px;
-  display: flex;
-  align-items: flex-start;
   position: absolute;
-  top: 6px;
-  right: 10px;
+  top: -18px;
+  right: -18px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+  z-index: 2;
 }
 
 .symbolCard__trend {
-  width: 32px;
-  height: 32px;
-  filter: drop-shadow(0 0 8px #7fff7f);
+  width: 56px;
+  height: 48px;
+  filter: drop-shadow(0 0 12px #7fff7f);
 }
 
 .symbolCard__priceRow {

--- a/frontend/src/components/SymbolCard/symbolCard.css
+++ b/frontend/src/components/SymbolCard/symbolCard.css
@@ -109,15 +109,17 @@
   justify-items: stretch;
 }
 
-@media (max-width: 1024px) {
+@media (max-width: 1280px) {
   .symbolCardGrid {
-    gap: 12px;
+    gap: 20px;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
   }
+}
 
-  .symbolCard {
+@media (max-width: 1024px) {
+  */ .symbolCard {
     background: #fff;
     border-radius: 12px;
-    box-shadow: 0 2px 16px 0 rgba(14, 17, 35, 0.1);
     margin: 0;
     min-width: 0;
     max-width: 100%;

--- a/frontend/src/components/SymbolCard/symbolCard.css
+++ b/frontend/src/components/SymbolCard/symbolCard.css
@@ -35,7 +35,7 @@
   border-radius: 12px 12px 0 0;
   font-size: 1.25rem;
   font-weight: 600;
-  padding: 12px 16px 10px 16px;
+  padding: 5px 16px;
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
@@ -93,12 +93,10 @@
 
 .symbolCard__flash--green {
   box-shadow: 0 0 16px 4px rgb(42, 161, 42, 0.8);
-  /* animation: symbolCardFlashGreenFade 1.2s cubic-bezier(0.4, 0, 0.2, 1); */
 }
 
 .symbolCard__flash--red {
   box-shadow: 0 0 16px 4px rgba(255, 127, 127, 0.8);
-  /* animation: symbolCardFlashRedFade 1.2s cubic-bezier(0.4, 0, 0.2, 1); */
 }
 
 .symbolCardGrid {
@@ -161,21 +159,3 @@
     transform: translateX(6px);
   }
 }
-
-/* @keyframes symbolCardFlashGreenFade {
-  0% {
-    box-shadow: 0 0 32px 8px rgba(127, 255, 127, 0.55);
-  }
-  100% {
-    box-shadow: 0 0 0 0 rgba(127, 255, 127, 0);
-  }
-}
-
-@keyframes symbolCardFlashRedFade {
-  0% {
-    box-shadow: 0 0 32px 8px rgba(255, 127, 127, 0.55);
-  }
-  100% {
-    box-shadow: 0 0 0 0 rgba(255, 127, 127, 0);
-  }
-} */

--- a/frontend/src/components/SymbolCard/symbolCard.css
+++ b/frontend/src/components/SymbolCard/symbolCard.css
@@ -15,7 +15,7 @@
 }
 
 .symbolCard--active {
-  box-shadow: 0 4px 32px 0 rgba(0, 0, 0, 1), 0 2px 16px 0 rgba(14, 17, 35, 0.1);
+  box-shadow: 0 4px 26px 0 rgba(0, 0, 0, 0.8), 0 2px 16px 0 rgba(14, 17, 35, 0.1);
   transform: scale(1.02);
   z-index: 1;
 }
@@ -91,17 +91,27 @@
   padding: 5px;
 }
 
+.symbolCard__flash--green {
+  box-shadow: 0 0 16px 4px rgb(42, 161, 42, 0.8);
+  /* animation: symbolCardFlashGreenFade 1.2s cubic-bezier(0.4, 0, 0.2, 1); */
+}
+
+.symbolCard__flash--red {
+  box-shadow: 0 0 16px 4px rgba(255, 127, 127, 0.8);
+  /* animation: symbolCardFlashRedFade 1.2s cubic-bezier(0.4, 0, 0.2, 1); */
+}
+
 .symbolCardGrid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
   grid-auto-rows: min-content;
-  gap: 24px;
+  gap: 40px;
   width: 100%;
   align-items: stretch;
   justify-items: stretch;
 }
 
-@media (max-width: 1023px) {
+@media (max-width: 1024px) {
   .symbolCardGrid {
     gap: 12px;
   }
@@ -151,3 +161,21 @@
     transform: translateX(6px);
   }
 }
+
+/* @keyframes symbolCardFlashGreenFade {
+  0% {
+    box-shadow: 0 0 32px 8px rgba(127, 255, 127, 0.55);
+  }
+  100% {
+    box-shadow: 0 0 0 0 rgba(127, 255, 127, 0);
+  }
+}
+
+@keyframes symbolCardFlashRedFade {
+  0% {
+    box-shadow: 0 0 32px 8px rgba(255, 127, 127, 0.55);
+  }
+  100% {
+    box-shadow: 0 0 0 0 rgba(255, 127, 127, 0);
+  }
+} */

--- a/frontend/src/components/SymbolCard/symbolCard.css
+++ b/frontend/src/components/SymbolCard/symbolCard.css
@@ -40,7 +40,6 @@
   align-items: flex-start;
   justify-content: space-between;
   width: 100%;
-  min-height: 38px;
   box-sizing: border-box;
   position: relative;
 }
@@ -95,6 +94,7 @@
 .symbolCardGrid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  grid-auto-rows: min-content;
   gap: 24px;
   width: 100%;
   align-items: stretch;

--- a/frontend/src/components/SymbolCard/symbolCard.css
+++ b/frontend/src/components/SymbolCard/symbolCard.css
@@ -15,7 +15,14 @@
 }
 
 .symbolCard--active {
-  /* Active state for the symbol card */
+  box-shadow: 0 4px 32px 0 rgba(0, 0, 0, 0.8), 0 2px 16px 0 rgba(14, 17, 35, 0.1);
+  transform: scale(1.02);
+  z-index: 1;
+}
+
+.symbolCard--inactive {
+  transform: scale(0.98);
+  z-index: 0;
 }
 
 .symbolCard__shake {

--- a/frontend/src/components/SymbolCard/symbolCard.css
+++ b/frontend/src/components/SymbolCard/symbolCard.css
@@ -2,16 +2,15 @@
   background: #fff;
   border-radius: 12px;
   box-shadow: 0 2px 16px 0 rgba(14, 17, 35, 0.1);
-  margin: 8px;
-  min-width: 240px;
-  max-width: 320px;
-  width: auto;
+  margin: 0;
+  min-width: 0;
+  max-width: 100%;
+  width: 100%;
   transition: box-shadow 0.2s, transform 0.2s;
   position: relative;
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  flex: 0 1 260px;
   box-sizing: border-box;
 }
 
@@ -85,12 +84,12 @@
 }
 
 .symbolCardGrid {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 16px;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 24px;
   width: 100%;
-  align-items: flex-start;
-  justify-content: flex-start;
+  align-items: stretch;
+  justify-items: stretch;
 }
 
 @media (max-width: 1023px) {
@@ -99,10 +98,19 @@
   }
 
   .symbolCard {
-    flex: 1 1 100%;
-    min-width: 90vw;
-    max-width: 100vw;
+    background: #fff;
+    border-radius: 12px;
+    box-shadow: 0 2px 16px 0 rgba(14, 17, 35, 0.1);
+    margin: 0;
+    min-width: 0;
+    max-width: 100%;
     width: 100%;
+    transition: box-shadow 0.2s, transform 0.2s;
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    box-sizing: border-box;
   }
 }
 

--- a/frontend/src/components/SymbolCard/symbolCard.css
+++ b/frontend/src/components/SymbolCard/symbolCard.css
@@ -1,11 +1,109 @@
 .symbolCard {
-  border: 2px solid black; /* just for visibility, feel free to remove it */
-  margin: 10px; /* just for visibility, feel free to remove it */
-  padding: 10px; /* just for visibility, feel free to remove it */
+  background: #fff;
+  border-radius: 12px;
+  box-shadow: 0 2px 16px 0 rgba(14, 17, 35, 0.1);
+  margin: 8px;
+  min-width: 240px;
+  max-width: 320px;
+  width: auto;
+  transition: box-shadow 0.2s, transform 0.2s;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  flex: 0 1 260px;
+  box-sizing: border-box;
+}
+
+.symbolCard--active {
+  /* Active state for the symbol card */
 }
 
 .symbolCard__shake {
   animation: shake 0.62s cubic-bezier(0.36, 0.07, 0.19, 0.97) both;
+}
+
+.symbolCard__header {
+  background: #181c2e;
+  color: #fff;
+  border-radius: 12px 12px 0 0;
+  font-size: 1.25rem;
+  font-weight: 600;
+  padding: 12px 16px 10px 16px;
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  width: 100%;
+  min-height: 38px;
+  box-sizing: border-box;
+  position: relative;
+}
+
+.symbolCard__trendWrapper {
+  margin-left: 8px;
+  display: flex;
+  align-items: flex-start;
+  position: absolute;
+  top: 6px;
+  right: 10px;
+}
+
+.symbolCard__trend {
+  width: 32px;
+  height: 32px;
+  filter: drop-shadow(0 0 8px #7fff7f);
+}
+
+.symbolCard__priceRow {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 8px;
+  width: 100%;
+  padding: 5px;
+}
+
+.symbolCard__priceLabel {
+  font-weight: 600;
+  font-size: 1.1rem;
+  color: #222;
+}
+
+.symbolCard__priceValue {
+  font-size: 2.2rem;
+  font-weight: 700;
+  color: #181c2e;
+  margin-left: 8px;
+}
+
+.symbolCard__info {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  width: 100%;
+  padding: 5px;
+}
+
+.symbolCardGrid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  width: 100%;
+  align-items: flex-start;
+  justify-content: flex-start;
+}
+
+@media (max-width: 1023px) {
+  .symbolCardGrid {
+    gap: 12px;
+  }
+
+  .symbolCard {
+    flex: 1 1 100%;
+    min-width: 90vw;
+    max-width: 100vw;
+    width: 100%;
+  }
 }
 
 @keyframes shake {

--- a/frontend/src/components/SymbolsGrid/SymbolsGrid.tsx
+++ b/frontend/src/components/SymbolsGrid/SymbolsGrid.tsx
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 import { useAppDispatch, useAppSelector } from '@/hooks/redux';
 import SymbolCard from '../SymbolCard';
 import { fetchAllStocks, selectors } from '@/store/stocksSlice';
+import { selectActiveSymbol } from '@/store/dashboardOptionsSlice';
 type SymbolsGridProps = {
   onSymbolClick: (symbolId: string) => void;
 };
@@ -9,6 +10,7 @@ type SymbolsGridProps = {
 const SymbolsGrid = ({ onSymbolClick }: SymbolsGridProps) => {
   const stockSymbols = useAppSelector(selectors.selectStockIds);
   const prices = useAppSelector((state) => state.prices);
+  const activeSymbol = useAppSelector(selectActiveSymbol);
   const dispatch = useAppDispatch();
   useEffect(() => {
     dispatch(fetchAllStocks());
@@ -17,7 +19,13 @@ const SymbolsGrid = ({ onSymbolClick }: SymbolsGridProps) => {
   return (
     <div>
       {stockSymbols.map((id, i) => (
-        <SymbolCard price={prices[id]} onClick={onSymbolClick} key={i} id={id} />
+        <SymbolCard
+          price={prices[id]}
+          onClick={onSymbolClick}
+          key={i}
+          id={id}
+          isActive={id === activeSymbol}
+        />
       ))}
     </div>
   );

--- a/frontend/src/components/SymbolsGrid/SymbolsGrid.tsx
+++ b/frontend/src/components/SymbolsGrid/SymbolsGrid.tsx
@@ -25,6 +25,7 @@ const SymbolsGrid = ({ onSymbolClick }: SymbolsGridProps) => {
           key={i}
           id={id}
           isActive={id === activeSymbol}
+          isInactive={!!activeSymbol && id !== activeSymbol}
         />
       ))}
     </div>

--- a/frontend/src/components/SymbolsGrid/SymbolsGrid.tsx
+++ b/frontend/src/components/SymbolsGrid/SymbolsGrid.tsx
@@ -17,7 +17,7 @@ const SymbolsGrid = ({ onSymbolClick }: SymbolsGridProps) => {
   }, [dispatch]);
 
   return (
-    <div>
+    <div className="symbolCardGrid">
       {stockSymbols.map((id, i) => (
         <SymbolCard
           price={prices[id]}

--- a/frontend/src/components/SymbolsGrid/SymbolsGrid.tsx
+++ b/frontend/src/components/SymbolsGrid/SymbolsGrid.tsx
@@ -1,35 +1,30 @@
-import { useEffect } from 'react';
+import { useEffect, useMemo, memo } from 'react';
 import { useAppDispatch, useAppSelector } from '@/hooks/redux';
 import SymbolCard from '../SymbolCard';
 import { fetchAllStocks, selectors } from '@/store/stocksSlice';
-import { selectActiveSymbol } from '@/store/dashboardOptionsSlice';
-type SymbolsGridProps = {
-  onSymbolClick: (symbolId: string) => void;
-};
 
-const SymbolsGrid = ({ onSymbolClick }: SymbolsGridProps) => {
+const SymbolsGrid = memo(() => {
   const stockSymbols = useAppSelector(selectors.selectStockIds);
-  const prices = useAppSelector((state) => state.prices);
-  const activeSymbol = useAppSelector(selectActiveSymbol);
   const dispatch = useAppDispatch();
+  
   useEffect(() => {
     dispatch(fetchAllStocks());
   }, [dispatch]);
 
+  const symbolCards = useMemo(() => {
+    return stockSymbols.map((id) => (
+      <SymbolCard
+        key={id}
+        id={id}
+      />
+    ));
+  }, [stockSymbols]);
+
   return (
     <div className="symbolCardGrid">
-      {stockSymbols.map((id, i) => (
-        <SymbolCard
-          price={prices[id]}
-          onClick={onSymbolClick}
-          key={i}
-          id={id}
-          isActive={id === activeSymbol}
-          isInactive={!!activeSymbol && id !== activeSymbol}
-        />
-      ))}
+      {symbolCards}
     </div>
   );
-};
+});
 
 export default SymbolsGrid;

--- a/frontend/src/components/SymbolsView/SymbolsView.css
+++ b/frontend/src/components/SymbolsView/SymbolsView.css
@@ -1,12 +1,7 @@
-/*
-  symbolsView.css
-  Responsive layout for SymbolsView: price chart on right (desktop), on top (mobile/tablet)
-*/
-
 .symbolsView {
   display: flex;
   flex-direction: column;
-  height: calc(100vh - 110px); /* Adjust for header/navbar */
+  height: calc(100vh - 110px);
   min-height: 0;
 }
 
@@ -20,21 +15,18 @@
 
 .symbolsView__cards {
   background-color: #e2e2e4;
-  flex: 1 1 0;
+  flex: 1 1 auto;
   min-width: 0;
   min-height: 0;
   overflow-y: auto;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 16px;
   order: 1;
   padding: 20px;
-  scrollbar-width: none; /* Firefox */
-  -ms-overflow-style: none; /* IE and Edge */
+  scrollbar-width: none;
+  -ms-overflow-style: none;
 }
 
 .symbolsView__cards::-webkit-scrollbar {
-  display: none; /* Chrome, Safari, Opera */
+  display: none;
 }
 
 .symbolsView__chart {

--- a/frontend/src/components/SymbolsView/SymbolsView.css
+++ b/frontend/src/components/SymbolsView/SymbolsView.css
@@ -40,7 +40,7 @@
   order: 2;
 }
 
-@media (max-width: 1023px) {
+@media (max-width: 1024px) {
   .symbolsView__content {
     flex-direction: column;
   }

--- a/frontend/src/components/SymbolsView/SymbolsView.css
+++ b/frontend/src/components/SymbolsView/SymbolsView.css
@@ -1,0 +1,67 @@
+/*
+  symbolsView.css
+  Responsive layout for SymbolsView: price chart on right (desktop), on top (mobile/tablet)
+*/
+
+.symbolsView {
+  display: flex;
+  flex-direction: column;
+  height: calc(100vh - 110px); /* Adjust for header/navbar */
+  min-height: 0;
+}
+
+.symbolsView__content {
+  display: flex;
+  flex: 1 1 0;
+  min-height: 0;
+  height: 100%;
+  padding-top: 20px;
+}
+
+.symbolsView__cards {
+  background-color: #e2e2e4;
+  flex: 1 1 0;
+  min-width: 0;
+  min-height: 0;
+  overflow-y: auto;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  order: 1;
+  padding: 20px;
+  scrollbar-width: none; /* Firefox */
+  -ms-overflow-style: none; /* IE and Edge */
+}
+
+.symbolsView__cards::-webkit-scrollbar {
+  display: none; /* Chrome, Safari, Opera */
+}
+
+.symbolsView__chart {
+  display: flex;
+  flex-direction: column;
+  width: 400px;
+  min-width: 400px;
+  max-width: 400px;
+  margin-left: 24px;
+  align-items: flex-start;
+  order: 2;
+}
+
+@media (max-width: 1023px) {
+  .symbolsView__content {
+    flex-direction: column;
+  }
+  .symbolsView__chart {
+    width: 100%;
+    min-width: 0;
+    max-width: 100vw;
+    margin-left: 0;
+    margin-bottom: 8px;
+    order: 1;
+  }
+  .symbolsView__cards {
+    order: 2;
+    gap: 12px;
+  }
+}

--- a/frontend/src/components/SymbolsView/SymbolsView.tsx
+++ b/frontend/src/components/SymbolsView/SymbolsView.tsx
@@ -1,12 +1,14 @@
 import SymbolsGrid from '@/components/SymbolsGrid';
 import PriceChart from '@/components/PriceChart';
 import DesktopInfo from './src/DesktopInfo';
-import { useState } from 'react';
+import { useAppDispatch, useAppSelector } from '@/hooks/redux';
+import { setActiveSymbol, selectActiveSymbol } from '@/store/dashboardOptionsSlice';
 
 const SymbolsView = () => {
-  const [activeSymbol, setActiveSymbol] = useState<null | string>(null);
+  const dispatch = useAppDispatch();
+  const activeSymbol = useAppSelector(selectActiveSymbol);
   const handleSymbolClick = (symbolId: string) => {
-    setActiveSymbol((s) => (s === symbolId ? null : symbolId));
+    dispatch(setActiveSymbol(symbolId === activeSymbol ? null : symbolId));
   };
 
   return (

--- a/frontend/src/components/SymbolsView/SymbolsView.tsx
+++ b/frontend/src/components/SymbolsView/SymbolsView.tsx
@@ -3,6 +3,7 @@ import PriceChart from '@/components/PriceChart';
 import DesktopInfo from './src/DesktopInfo';
 import { useAppDispatch, useAppSelector } from '@/hooks/redux';
 import { setActiveSymbol, selectActiveSymbol } from '@/store/dashboardOptionsSlice';
+import './symbolsView.css';
 
 const SymbolsView = () => {
   const dispatch = useAppDispatch();
@@ -13,14 +14,14 @@ const SymbolsView = () => {
 
   return (
       <div className="symbolsView">
-        <DesktopInfo/>
-        <div className="symbolsView__chart">
-          <h3>PRICE HISTORY</h3>
-        </div>
+        <DesktopInfo />
         <div className="symbolsView__content">
-          <PriceChart symbolId={activeSymbol}/>
-          <div className="symbolsView__cards">
-            <SymbolsGrid onSymbolClick={handleSymbolClick}/>
+          <div className="symbolsView__cards symbolCardGrid">
+            <SymbolsGrid onSymbolClick={handleSymbolClick} />
+          </div>
+          <div className="symbolsView__chart">
+            <h3>PRICE HISTORY</h3>
+            <PriceChart symbolId={activeSymbol} />
           </div>
         </div>
       </div>

--- a/frontend/src/components/SymbolsView/SymbolsView.tsx
+++ b/frontend/src/components/SymbolsView/SymbolsView.tsx
@@ -1,23 +1,19 @@
 import SymbolsGrid from '@/components/SymbolsGrid';
 import PriceChart from '@/components/PriceChart';
 import DesktopInfo from './src/DesktopInfo';
-import { useAppDispatch, useAppSelector } from '@/hooks/redux';
-import { setActiveSymbol, selectActiveSymbol } from '@/store/dashboardOptionsSlice';
+import { useAppSelector } from '@/hooks/redux';
+import { selectActiveSymbol } from '@/store/dashboardOptionsSlice';
 import './symbolsView.css';
 
 const SymbolsView = () => {
-  const dispatch = useAppDispatch();
   const activeSymbol = useAppSelector(selectActiveSymbol);
-  const handleSymbolClick = (symbolId: string) => {
-    dispatch(setActiveSymbol(symbolId === activeSymbol ? null : symbolId));
-  };
 
   return (
       <div className="symbolsView">
         <DesktopInfo />
         <div className="symbolsView__content">
           <div className="symbolsView__cards symbolCardGrid">
-            <SymbolsGrid onSymbolClick={handleSymbolClick} />
+            <SymbolsGrid />
           </div>
           <div className="symbolsView__chart">
             <h3>PRICE HISTORY</h3>

--- a/frontend/src/components/SymbolsView/src/desktopInfo.css
+++ b/frontend/src/components/SymbolsView/src/desktopInfo.css
@@ -1,4 +1,4 @@
-@media (max-width: 1023px) {
+@media (max-width: 1024px) {
   .desktopInfo {
     display: none;
   }

--- a/frontend/src/hooks/useFlashEffect.ts
+++ b/frontend/src/hooks/useFlashEffect.ts
@@ -3,7 +3,6 @@ import { useEffect, useRef, useState } from 'react';
 export function useFlashEffect(price: number, durationMs = 1200) {
   const [flashClass, setFlashClass] = useState('');
   const prevPrice = useRef<number | null>(null);
-  const animatingRef = useRef(false);
 
   useEffect(() => {
     if (prevPrice.current === null) {
@@ -13,16 +12,14 @@ export function useFlashEffect(price: number, durationMs = 1200) {
     if (price === prevPrice.current) return;
     const diff = price - prevPrice.current;
     if (diff === 0) return;
-    setFlashClass('');
-    setTimeout(() => {
-      setFlashClass(diff > 0 ? 'symbolCard__flash--green' : 'symbolCard__flash--red');
-      animatingRef.current = true;
-      setTimeout(() => {
-        setFlashClass('');
-        animatingRef.current = false;
-      }, durationMs);
-    }, 10);
+    const newClass = diff > 0 ? 'symbolCard__flash--green' : 'symbolCard__flash--red';
+    setFlashClass(newClass);
+    const timeoutId = setTimeout(() => {
+      setFlashClass('');
+    }, durationMs);
+
     prevPrice.current = price;
+    return () => clearTimeout(timeoutId);
   }, [price, durationMs]);
 
   return { flashClass };

--- a/frontend/src/hooks/useFlashEffect.ts
+++ b/frontend/src/hooks/useFlashEffect.ts
@@ -1,0 +1,29 @@
+import { useEffect, useRef, useState } from 'react';
+
+export function useFlashEffect(price: number, durationMs = 1200) {
+  const [flashClass, setFlashClass] = useState('');
+  const prevPrice = useRef<number | null>(null);
+  const animatingRef = useRef(false);
+
+  useEffect(() => {
+    if (prevPrice.current === null) {
+      prevPrice.current = price;
+      return;
+    }
+    if (price === prevPrice.current) return;
+    const diff = price - prevPrice.current;
+    if (diff === 0) return;
+    setFlashClass('');
+    setTimeout(() => {
+      setFlashClass(diff > 0 ? 'symbolCard__flash--green' : 'symbolCard__flash--red');
+      animatingRef.current = true;
+      setTimeout(() => {
+        setFlashClass('');
+        animatingRef.current = false;
+      }, durationMs);
+    }, 10);
+    prevPrice.current = price;
+  }, [price, durationMs]);
+
+  return flashClass;
+}

--- a/frontend/src/hooks/useFlashEffect.ts
+++ b/frontend/src/hooks/useFlashEffect.ts
@@ -25,5 +25,5 @@ export function useFlashEffect(price: number, durationMs = 1200) {
     prevPrice.current = price;
   }, [price, durationMs]);
 
-  return flashClass;
+  return { flashClass };
 }

--- a/frontend/src/hooks/useShakeEffect.ts
+++ b/frontend/src/hooks/useShakeEffect.ts
@@ -1,0 +1,35 @@
+import { useEffect, useRef, useState } from 'react';
+
+export function useShakeEffect(price: number, durationMs = 620) {
+  const [shakeClass, setShakeClass] = useState('');
+  const prevPrice = useRef<number | null>(null);
+  const shakeTimeout = useRef<NodeJS.Timeout | null>(null);
+
+  useEffect(() => {
+    if (prevPrice.current === null) {
+      prevPrice.current = price;
+      return;
+    }
+    if (price === prevPrice.current) return;
+    const diff = price - prevPrice.current;
+    if (diff === 0) return;
+    const prev = prevPrice.current;
+    const percentChange = Math.abs(diff) / Math.abs(prev);
+    if (percentChange > 0.25) {
+      setShakeClass('symbolCard__shake');
+      if (shakeTimeout.current) clearTimeout(shakeTimeout.current);
+      shakeTimeout.current = setTimeout(() => {
+        setShakeClass('');
+      }, durationMs);
+    }
+    prevPrice.current = price;
+  }, [price, durationMs]);
+
+  useEffect(() => {
+    return () => {
+      if (shakeTimeout.current) clearTimeout(shakeTimeout.current);
+    };
+  }, []);
+
+  return { shakeClass };
+}

--- a/frontend/src/hooks/useShakeEffect.ts
+++ b/frontend/src/hooks/useShakeEffect.ts
@@ -3,7 +3,6 @@ import { useEffect, useRef, useState } from 'react';
 export function useShakeEffect(price: number, durationMs = 620) {
   const [shakeClass, setShakeClass] = useState('');
   const prevPrice = useRef<number | null>(null);
-  const shakeTimeout = useRef<NodeJS.Timeout | null>(null);
 
   useEffect(() => {
     if (prevPrice.current === null) {
@@ -17,19 +16,15 @@ export function useShakeEffect(price: number, durationMs = 620) {
     const percentChange = Math.abs(diff) / Math.abs(prev);
     if (percentChange > 0.25) {
       setShakeClass('symbolCard__shake');
-      if (shakeTimeout.current) clearTimeout(shakeTimeout.current);
-      shakeTimeout.current = setTimeout(() => {
+      const timeoutId = setTimeout(() => {
         setShakeClass('');
       }, durationMs);
+      
+      prevPrice.current = price;
+      return () => clearTimeout(timeoutId);
     }
     prevPrice.current = price;
   }, [price, durationMs]);
-
-  useEffect(() => {
-    return () => {
-      if (shakeTimeout.current) clearTimeout(shakeTimeout.current);
-    };
-  }, []);
 
   return { shakeClass };
 }

--- a/frontend/src/router/index.tsx
+++ b/frontend/src/router/index.tsx
@@ -1,16 +1,20 @@
-import SymbolsView from '@/components/SymbolsView';
+import { Suspense, lazy } from 'react';
 import { Route, Routes, Navigate } from 'react-router-dom';
-import StatementsView from "@/components/StatementsView";
-import ProfileView from "@/components/ProfileView";
+
+const SymbolsView = lazy(() => import('@/components/SymbolsView'));
+const StatementsView = lazy(() => import('@/components/StatementsView'));
+const ProfileView = lazy(() => import('@/components/ProfileView'));
 
 const Router = () => {
   return (
+    <Suspense fallback={<div>Loading...</div>}>
       <Routes>
         <Route index element={<SymbolsView />} />
         <Route index path="profile" element={<ProfileView />} />
         <Route index path="statements" element={<StatementsView />} />
         <Route path="*" element={<Navigate to="/" />} />
       </Routes>
+    </Suspense>
   );
 };
 

--- a/frontend/src/store/dashboardOptionsSlice.ts
+++ b/frontend/src/store/dashboardOptionsSlice.ts
@@ -16,12 +16,16 @@ export const dashboardOptionsSlice = createSlice({
   reducers: {
     toggleShowCardInfo: (state) => {
       state.showCardInfo = !state.showCardInfo;
+    },
+    setActiveSymbol: (state, action) => {
+      state.activeSymbol = action.payload;
     }
   }
 });
 
-export const { toggleShowCardInfo } = dashboardOptionsSlice.actions;
+export const { toggleShowCardInfo, setActiveSymbol } = dashboardOptionsSlice.actions;
 
 export const selectShowCardInfo = (state: { store: StoreState }) => state.store.showCardInfo;
+export const selectActiveSymbol = (state: { store: StoreState }) => state.store.activeSymbol;
 
 export default dashboardOptionsSlice.reducer;

--- a/frontend/src/store/priceHistorySlice.ts
+++ b/frontend/src/store/priceHistorySlice.ts
@@ -47,7 +47,14 @@ const apiState = (state: RootState) => state.priceHistory.apiState;
 const priceHistorySlice = createSlice({
   name: 'priceHistory',
   initialState,
-  reducers: {},
+  reducers: {
+    reset: (state) => {
+      state.symbol = null;
+      state.history = [];
+      state.apiState.loading = null;
+      state.apiState.error = false;
+    }
+  },
   extraReducers: (builder) => {
     // Add reducers for additional action types here, and handle loading state as needed
     builder.addCase(fetchPriceHistory.fulfilled, (state, action) => {
@@ -79,4 +86,5 @@ const selectors = {
 };
 
 export default priceHistorySlice;
+export const { reset } = priceHistorySlice.actions;
 export { selectors };

--- a/frontend/src/utils/formatNumber.ts
+++ b/frontend/src/utils/formatNumber.ts
@@ -1,7 +1,12 @@
 export function formatNumber(value: number): string {
   if (value == null || isNaN(value)) return '--';
   const abs = Math.abs(value);
-  if (abs < 1_000) return `$${Math.round(value)}`;
+  if (abs < 1_000) {
+    if (abs < 10) {
+      return `$${value.toFixed(1)}`;
+    }
+    return `$${Math.round(value)}`;
+  }
   if (abs < 1_000_000) return `$${Math.round(value / 1_000)}K`;
   if (abs < 1_000_000_000) return `$${Math.round(value / 1_000_000)}M`;
   if (abs < 1_000_000_000_000) return `$${Math.round(value / 1_000_000_000)}B`;

--- a/frontend/src/utils/formatNumber.ts
+++ b/frontend/src/utils/formatNumber.ts
@@ -1,0 +1,9 @@
+export function formatNumber(value: number): string {
+  if (value == null || isNaN(value)) return '--';
+  const abs = Math.abs(value);
+  if (abs < 1_000) return `$${Math.round(value)}`;
+  if (abs < 1_000_000) return `$${Math.round(value / 1_000)}K`;
+  if (abs < 1_000_000_000) return `$${Math.round(value / 1_000_000)}M`;
+  if (abs < 1_000_000_000_000) return `$${Math.round(value / 1_000_000_000)}B`;
+  return `$${(value / 1_000_000_000_000).toFixed(1).replace(/\.0$/, '')}T`;
+}


### PR DESCRIPTION
# Description

This is my implementation of the MrQ Lindar Challenge. I've tried my best to replicate my implementation as close as possible to the one shown in the instructions, keeping in mind the most efficient approach. I've attempted to implement all suggestions provided, including the Race Condition fix, Utilizing Redux for persisting the active state of the card, and reducing the initial bundle size with Suspense and React.lazy

## Types of changes

1. Fully Replicated the Card Including the Glow States, Active/InActive States, The trend indicators, and Shake Animations
2. Utilized Custom Hooks for the Shake & Flash Logic
3. for the Active State, The card gets a black box-shadow with a 2% increase and the inactive cards get another 2% decrease, The shake animation is triggered upon a 25% price change, and the Red/Green Flash is triggered on whether the price goes up or down
4. Used a Granular Approach when restructuring the SymbolCard. 
     -  SymbolCard.tsx (Main Smart Card)
     - SymbolCardHeader.tsx
     - SymbolCardPrice.tsx
     - SymbolCardInfo.tsx
     - SymbolCardTrendIcon.tsx    
5. Replicated the Scroll behaviour
6. Replicated the card Container utilizing grid
7. Fixed the +Info functionality
8. The performance amount, the stock price and the market cap have all been formatted as shown in the videos utilizing a helper function. 
9. Utilized Redux the fix the persistence of the active state of the card
10. Fully Responsive Web App as shown in the instruction videos.
11. Improved Initial Loading time using Suspense and React.lazy
12. Fixed Race Condition Issue to improve what data is shown more accurately
13. Adhered to the standard Component Structure & Utilized BEM Methodology For CSS Classes
14. When Animations run, only the affected parts of the components is updated, keeping re-rendering to an absolute minimum
15. Price Chart Retains the width of 400px. With the dashboard changing at 1024px (Performance Graph disappears, as well as price chart appearing on top rather than to the right), at 1280px There is also a change in the size of the cards to replicate  the dashboard even further.

A more detailed explanation on certain problems and results can be found here: 

frontend/notes.md

## How has this been tested?

This has been tested on local environment on Windows and on MacOS.
Responsiveness has been tested rigorously on different viewports 

## Screenshots

Desktop: 
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/1b551589-2446-4d62-8759-a6af8cba6125" />

Mobile: 
<img width="604" alt="image" src="https://github.com/user-attachments/assets/b67c3a32-b95c-471b-9c8e-8d29c40f6d32" />

## Checklist:

- [x] My code is tested on Mac And Windows Operating Systems
- [x] My code is Responsive across all different viewports 
- [x] My code aheres to all the requirements listed in the README File available 
